### PR TITLE
feat: add trait tags (colored boxes)

### DIFF
--- a/cards.tex
+++ b/cards.tex
@@ -46,6 +46,22 @@
 \newcommand{\Reference}[2]{{\small \color{gray} \engschrift #1 #2}}
 \newcommand{\DamageType}[1]{\operatorname{\mbox{#1}}}
 
+\newcommand{\Tag}[2]{%
+    \tikz[baseline]{%
+        \node[anchor=base, text=white, fill=#1, font=\sffamily, text depth=.5mm] {#2};
+    }%
+}
+
+\definecolor{tagsBg}{RGB}{217, 196, 132}
+\definecolor{uncommonBg}{RGB}{152, 81, 61}
+\definecolor{rareBg}{RGB}{0, 38, 100}
+\definecolor{traitBg}{RGB}{94, 0, 0}
+
+\newcommand{\Trait}[1]{\Tag{traitBg}{#1}}
+\newcommand{\Rare}[0]{\Tag{rareBg}{Rare}}
+\newcommand{\Uncommon}[0]{\Tag{uncommonBg}{Uncommon}}
+
+\newcommand{\Traits}[1]{\colorbox{tagsBg}{#1}}
 
 \section{Frightened}
 
@@ -73,7 +89,7 @@ Gain \(+2\) circumstance bonus to AC until the start of your next turn.
 
 \CheckFormula{strength, profic., item, status, circum.}
 
-\(\operatorname{1d4} + \FormulaVariable{strength}{\phantom{1}} \DamageType{Bludgeoning}\)
+\(\operatorname{1d4} + \FormulaVariable{strength}{\phantom{1}} \hfill \DamageType{Bludgeoning}\)
 
 \ItemPrice{2gp}
 \ItemBulk{1}
@@ -83,6 +99,8 @@ Gain \(+2\) circumstance bonus to AC until the start of your next turn.
 \WeaponGroup{Shield}
 
 \Item{3}{Smoking Sword}
+
+\Traits{\Trait{Evocation} \Trait{Fire} \Trait{Magical}}
 
 \Flavor{Smoke constantly belches from this magic longsword.}
 
@@ -110,6 +128,8 @@ Until the end of your turn, the blade deals 1d6 extra fire damage instead of jus
 \foreach[evaluate=\level as \bonus using int(\level*8)] \level in {1, ..., 10} {
 \Spell{\level}{Heal}
 
+\Traits{\Trait{Healing} \Trait{Necromancy} \Trait{Positive}}
+
 \Flavor{You channel positive energy.}
 
 Restore \(\operatorname{\level d8}\) hit points to willing living creatures.\\
@@ -134,6 +154,8 @@ Target every creature within 30 feet.
 
 \foreach[evaluate=\level as \bonus using int(\level*8)] \level in {1, ..., 10} {
 \Cantrip{\level}{Ray of Frost}
+
+\Traits{\Trait{Attack} \Trait{Cantrip} \Trait{Cold} \Trait{Evocation}}
 
 \Flavor{You blast an icy ray.}
 

--- a/cards.tex
+++ b/cards.tex
@@ -130,7 +130,8 @@ Until the end of your turn, the blade deals 1d6 extra fire damage instead of jus
 
 \Traits{\Trait{Healing} \Trait{Necromancy} \Trait{Positive}}
 
-\Flavor{You channel positive energy.}
+% TODO make room for some flavor text?
+% \Flavor{You channel positive energy.}
 
 Restore \(\operatorname{\level d8}\) hit points to willing living creatures.\\
 Deal \(\operatorname{\level d8}\) positive damage to undead creatures.\\


### PR DESCRIPTION
This adds _some_ colored boxes for traits and rarity.

The colors should be matching those of the books and https://pf2easy.com/.

This likely needs some adjustments before merging, for instance:
- reduce height of the tag row?
- should the tags be rendered with `tikz`, `colorbox`, some other package?
- move tags closer to card title

<img width="550" alt="image" src="https://github.com/Toxaris/pathfinder2-cards/assets/1448874/cda78be0-3e4e-4068-8420-1ae517168816">

And to show the colors for "Rare" and "Uncommon" items:

<img width="550" alt="image" src="https://github.com/Toxaris/pathfinder2-cards/assets/1448874/5877f484-5bca-4f48-9f90-0f53fcb62de6">

