### PR TITLE
Configure Latex Workshop VSCode plugin to use XeLaTeX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.aux
 *.log
 *.pdf
+*.fdb_latexmk
+*.fls
+*.synctex.gz
+*.xdv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "latex-workshop.latex.recipe.default": "latexmk (xelatex)"
+}


### PR DESCRIPTION
Also add files to .gitignore, that are generated by latexmk.