### PR TITLE
Create github page to make cards.pdf available

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,73 @@
+name: Deploy Github Page
+
+on:
+  workflow_run:
+    workflows: [compile]
+    types:
+      - completed
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Create destination directory
+        run: mkdir _site
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - name: Download cards.pdf
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "result"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs').promises;
+            await fs.writeFile('_site/result.zip', Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip result.zip
+        working-directory: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+Generate item cards for Pathfinder2.
+
+[View some sample cards](./cards.pdf)


### PR DESCRIPTION
This is done via a github workfloaw, that is run after the LaTeX build workflow is done.
It only happens when it's executed on the main branch.

This has the drawback, that it currently doesn't show as check on the commit.

With this commit merged, we have a small website at https://toxaris.github.com/pathfinder2-cards and our cards.pdf is available at https://toxaris.github.io/pathfinder2-cards/cards.pdf. I tested this on a fork, which appears to work (see https://fkz.github.io/pathfinder2-cards).

This allows to view the generated cards.pdf directly on a website.