### PR TITLE
Add information about licenses on the website

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Create destination directory
         run: mkdir _site
+      - name: Copy information about licenses from README.md
+        run: mkdir -p docs/_includes && sed -n '/Licenses/,$p' README.md > docs/_includes/LICENSES.md
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ LaTeX styles and software for generating printable playing cards for Pathfinder 
 
 **LaTeX styles and software** is provided under MIT license, see [LICENSE].
 
-Example **rules text** is taken from https://2e.aonprd.com/ and used under OGL.
+Example **rules text** is taken from <https://2e.aonprd.com/> and used under OGL.
 
-The font **STIX2** is taken from https://ctan.org/tex-archive/fonts/stix2-otf and used under the [SIL Open Font License], see [LICENSE-STIX2].
+The font **STIX2** is taken from <https://ctan.org/tex-archive/fonts/stix2-otf> and used under the [SIL Open Font License], see [LICENSE-STIX2].
 
-The font **Alte DIN 1451** is taken from http://www.peter-wiegel.de/alteDin1451.html and used under the [SIL Open Font License], see [LICENSE-alteDin1451].
+The font **Alte DIN 1451** is taken from <http://www.peter-wiegel.de/alteDin1451.html> and used under the [SIL Open Font License], see [LICENSE-alteDin1451].
 
-The font **TGL 0-1451 Engschrift** is taken from http://www.peter-wiegel.de/TGL_0-1451.html and used based on the permissions on the FAQ in http://www.peter-wiegel.de. The downloads page states that all fonts are provided under Creative Commons, GPL with Font-Exception and/or SIL Open Font License. Unfortunately it is not clear which of these licenses is supposed to apply to the TGL 0-1451 Engschrift font in particular.
+The font **TGL 0-1451 Engschrift** is taken from <http://www.peter-wiegel.de/TGL_0-1451.html> and used based on the permissions on the FAQ in <http://www.peter-wiegel.de>. The downloads page states that all fonts are provided under Creative Commons, GPL with Font-Exception and/or SIL Open Font License. Unfortunately it is not clear which of these licenses is supposed to apply to the TGL 0-1451 Engschrift font in particular.
 
-The font **Postamt** is taken from http://www.peter-wiegel.de/Postamt.html and used based on the permissions on the FAQ in http://www.peter-wiegel.de. The downloads page states that all fonts are provided under Creative Commons, GPL mit Font-Exception and/or SIL Open Font License. Unfortunately it is not clear which of these licenses is supposed to apply to the Postamt font in particular.
+The font **Postamt** is taken from <http://www.peter-wiegel.de/Postamt.html> and used based on the permissions on the FAQ in <http://www.peter-wiegel.de>. The downloads page states that all fonts are provided under Creative Commons, GPL mit Font-Exception and/or SIL Open Font License. Unfortunately it is not clear which of these licenses is supposed to apply to the Postamt font in particular.
 
-Various icons are taken from https://game-icons.net/ and used under [CC-by-3.0], see the comments in [symbols.tex] on the SVG path data.
+Various icons are taken from <https://game-icons.net/> and used under [CC-by-3.0], see the comments in [symbols.tex] on the SVG path data.
 
 [cc-by-3.0]: http://creativecommons.org/licenses/by/3.0/
 [license]: LICENSE

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,12 @@
-Generate item cards for Pathfinder2.
+Generate printable playing cards for Pathfinder 2.
 
 [View some sample cards](./cards.pdf)
+
+These have been generated using the software provided at <https://github.com/toxaris/pathfinder2-cards>.
+
+{% include LICENSES.md %}
+
+[license]: https://github.com/Toxaris/pathfinder2-cards/blob/main/LICENSE
+[license-altedin1451]: https://github.com/Toxaris/pathfinder2-cards/blob/main/LICENSE-alteDin1451
+[license-stix2]: https://github.com/Toxaris/pathfinder2-cards/blob/main/LICENSE-STIX2
+[symbols.tex]: https://github.com/Toxaris/pathfinder2-cards/blob/main/symbols.tex


### PR DESCRIPTION
This works by copying this information over from the main README. 
Some of the links are changed in docs/README.md to point back to the respective file in the github repository.