### PR TITLE
Change github build action to workflow call

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,8 +8,11 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  pages: write
+  id-token: write
 jobs:
   compile:
+    name: Generate cards.pdf
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -24,3 +27,7 @@ jobs:
       with:
         name: result
         path: cards.pdf
+  gh-pages:
+    name: Generate website
+    uses: ./.github/workflows/gh-pages.yml
+    needs: compile

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,11 +1,7 @@
 name: Deploy Github Page
 
 on:
-  workflow_run:
-    workflows: [compile]
-    types:
-      - completed
-    branches: ["main"]
+  workflow_call:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -21,12 +17,11 @@ concurrency:
 
 jobs:
   build:
+    name: Build website
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Create destination directory
@@ -39,36 +34,20 @@ jobs:
           source: ./docs
           destination: ./_site
       - name: Download cards.pdf
-        uses: actions/github-script@v6
+        uses: actions/download-artifact@v3
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "result"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs').promises;
-            await fs.writeFile('_site/result.zip', Buffer.from(download.data));
-      - name: 'Unzip artifact'
-        run: unzip result.zip
-        working-directory: ./_site
+          name: result
+          path: _site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
   deploy:
+    name: Deploy website
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Previously, this was done by a workflow_run - where the github-pages workflow is started once the compile workflow is finished.
With this PR, we call the github-pages workflow from the compile workflow.

Advantage:
- The compile workflow is only finished once the github-pages workflow is also finished, as it's now part of it
- The github-pages workflow is part of the github check
- The github-pages workflow uses the correct source branch and artifacts automatically (without previously needed configuration)
- We also build the github page when not on main (but only deploy on the main branch)

Disadvantage:
- The compile workflow needs more permissions now, that were previously only necessary in the github-pages workflow (as you need all permissions of another workflow when calling it)