### PR TITLE
feat: render box for current HP

### DIFF
--- a/cards.tex
+++ b/cards.tex
@@ -48,8 +48,7 @@
 \newcommand{\Flavor}[1]{\textit{#1}}
 
 \newcommand{\Hardness}[1]{\Attribute{Hardness}{#1}}
-% TODO: Render a box to enter current hit points
-\newcommand{\HitPoints}[1]{\Attribute{HP}{#1}}
+\newcommand{\HitPoints}[1]{\Attribute{HP}{\(\FormulaVariable{current}{\phantom{100}}\) / #1}}
 \newcommand{\BrokenThreshold}[1]{\Attribute{BT}{#1}}
 
 \newcommand{\Reference}[2]{{\small \color{gray} \engschrift #1 #2}}

--- a/cards.tex
+++ b/cards.tex
@@ -28,47 +28,7 @@
 \renewcommand*{\sectionformat}{}
 \renewcommand*{\subsectionformat}{}
 
-% TODO: move all these custom commands to a different file?
-%       would allow for simpler reuse in a macro reference overview
-
 \newcommand{\Card}[3]{\section{#3 \hfill \color{gray} #1 #2}}
-
-\newcommand{\Action}[5][]{\subsection[#5]{#5\ActionSymbol{#4} \ifx&#1&\else{\normalsize\engschrift (#1)}\fi \hfill \Reference{#2}{#3}}}
-
-\newcommand{\Requirements}[1]{\paragraph{Requirements} #1.}
-
-\newcommand{\Attribute}[2]{\smallskip\mbox{\engschrift \color{gray} #1 \normalcolor #2}}
-\newcommand{\WeaponDamage}[1]{\Attribute{Damage}{#1}}
-\newcommand{\ItemHands}[1]{\Attribute{Hands}{#1}}
-\newcommand{\ItemBulk}[1]{\Attribute{Bulk}{#1}}
-\newcommand{\ItemPrice}[1]{\Attribute{Price}{#1}}
-\newcommand{\WeaponType}[1]{\Attribute{Type}{#1}}
-\newcommand{\WeaponCategory}[1]{\Attribute{Category}{#1}}
-\newcommand{\WeaponGroup}[1]{\Attribute{Group}{#1}}
-\newcommand{\Flavor}[1]{\textit{#1}}
-
-\newcommand{\Hardness}[1]{\Attribute{Hardness}{#1}}
-\newcommand{\HitPoints}[1]{\Attribute{HP}{\(\FormulaVariable{current}{\phantom{100}}\) / #1}}
-\newcommand{\BrokenThreshold}[1]{\Attribute{BT}{#1}}
-
-\newcommand{\Reference}[2]{{\small \color{gray} \engschrift #1 #2}}
-
-\newcommand{\Tag}[2]{%
-    \tikz[baseline]{%
-        \node[anchor=base, text=white, fill=#1, font=\sffamily, text depth=.5mm] {#2};
-    }%
-}
-
-\definecolor{tagsBg}{RGB}{217, 196, 132}
-\definecolor{uncommonBg}{RGB}{152, 81, 61}
-\definecolor{rareBg}{RGB}{0, 38, 100}
-\definecolor{traitBg}{RGB}{94, 0, 0}
-
-\newcommand{\Trait}[1]{\Tag{traitBg}{#1}}
-\newcommand{\Rare}[0]{\Tag{rareBg}{Rare}}
-\newcommand{\Uncommon}[0]{\Tag{uncommonBg}{Uncommon}}
-
-\newcommand{\Traits}[1]{\colorbox{tagsBg}{#1}}
 
 \section{Symbol Reference}
 
@@ -287,7 +247,6 @@ Target 1 creature within 30 feet.
 
 \Card{Action}{}{Demoralize}
 \Traits{\Trait{Emotion} \Trait{Fear} \Trait{Mental}}
-
 
 \Flavor{With a sudden shout, a well-timed taunt, or a cutting putdown, you can shake an enemy's resolve.}
 

--- a/cards.tex
+++ b/cards.tex
@@ -106,7 +106,7 @@
 
 \begin{tabular}{ll}
     \Reference{CRB}{}        & Core rule book \\
-    \HitPoints{}             & Hit points \\
+    \HitPoints               & Hit points \\
     \BrokenThreshold{}       & Broken threashold \\
     DC                       & Difficulty class \\
     AC                       & Armor class \\
@@ -132,7 +132,7 @@ Unless specified otherwise, at the end of each of your turns, the value of your 
 
 % TODO: How should we render these item stats?
 \Hardness{5}
-\HitPoints{20}
+\HitPoints[20]
 \BrokenThreshold{10}
 
 \Action{CRB}{472}{1}{Raise a Shield}

--- a/symbols.tex
+++ b/symbols.tex
@@ -7,6 +7,49 @@
   \mbox{\pfsymbols\selectfont#1}
 }
 
+\newcommand{\Action}[5][]{\subsection[#5]{#5\ActionSymbol{#4} \ifx&#1&\else{\normalsize\engschrift (#1)}\fi \hfill \Reference{#2}{#3}}}
+
+\newcommand{\Requirements}[1]{\paragraph{Requirements} #1.}
+
+\newcommand{\Attribute}[2]{\smallskip\mbox{\engschrift \color{gray} #1 \normalcolor #2}}
+\newcommand{\WeaponDamage}[1]{\Attribute{Damage}{#1}}
+\newcommand{\ItemHands}[1]{\Attribute{Hands}{#1}}
+\newcommand{\ItemBulk}[1]{\Attribute{Bulk}{#1}}
+\newcommand{\ItemPrice}[1]{\Attribute{Price}{#1}}
+\newcommand{\WeaponType}[1]{\Attribute{Type}{#1}}
+\newcommand{\WeaponCategory}[1]{\Attribute{Category}{#1}}
+\newcommand{\WeaponGroup}[1]{\Attribute{Group}{#1}}
+\newcommand{\Flavor}[1]{\textit{#1}}
+
+\newcommand{\Hardness}[1]{\Attribute{Hardness}{#1}}
+\newcommand{\BrokenThreshold}[1]{\Attribute{BT}{#1}}
+
+\NewDocumentCommand{\HitPoints}{o}{%
+  \Attribute{HP}{%
+    \IfNoValueTF{#1}
+      {}
+      {\(\FormulaVariable{current}{\phantom{100}}\) / #1}}%
+}
+
+\newcommand{\Reference}[2]{{\small \color{gray} \engschrift #1 #2}}
+
+\newcommand{\Tag}[2]{%
+    \tikz[baseline]{%
+        \node[anchor=base, text=white, fill=#1, font=\sffamily, text depth=.5mm] {#2};
+    }%
+}
+
+\definecolor{tagsBg}{RGB}{217, 196, 132}
+\definecolor{uncommonBg}{RGB}{152, 81, 61}
+\definecolor{rareBg}{RGB}{0, 38, 100}
+\definecolor{traitBg}{RGB}{94, 0, 0}
+
+\newcommand{\Trait}[1]{\Tag{traitBg}{#1}}
+\newcommand{\Rare}[0]{\Tag{rareBg}{Rare}}
+\newcommand{\Uncommon}[0]{\Tag{uncommonBg}{Uncommon}}
+
+\newcommand{\Traits}[1]{\colorbox{tagsBg}{#1}}
+
 % TODO fix distance between actions, maybe avoid draw in favor of more fill?
 \newcommand{\ActionSymbol}[1]{
   \ifnum\strcmp{#1}{R} = 0


### PR DESCRIPTION
The hit points are a mutable value that changes during gameplay. Thus, add a box with space for the player to write down the current hit points.

```tex
\HitPoints[20]
```
<img width="420" alt="image" src="https://github.com/Toxaris/pathfinder2-cards/assets/1448874/8bae2805-9d40-4d9e-96f9-2246be840f9e">

```tex
\HitPoints
```
<img width="420" alt="image" src="https://github.com/Toxaris/pathfinder2-cards/assets/1448874/3302bdbd-8df1-4138-921d-07239c6beae4">
