### PR TITLE
Fix Crossbow: Don't add strength to damage

### DIFF
--- a/cards/items/crossbow.tex
+++ b/cards/items/crossbow.tex
@@ -16,7 +16,7 @@ trigger mechanism that releases the tension and launches a bolt.
 \Attribute{Ammo}{\(\FormulaVariable{}{\phantom{100}}\)}
 
 \CheckRoll{RangeAttack}{dex, prof}
-\DamageRoll{Piercing}{1d8}{str}
+\DamageRoll{Piercing}{1d8}{}
 
 \Action[Manipulate]{CRB}{279}{1}{Reload}
 


### PR DESCRIPTION
strength is only added for melee weapons and weapons with "thrown" trait