### PR TITLE
Add a4print.tex, that puts all the cards on a4 paper

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,21 +21,23 @@ jobs:
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v2
       with:
-        root_file: cards.tex
+        root_file: |
+           cards.tex
+           a4print.tex
         latexmk_use_xelatex: true
         pre_compile: "export max_print_line=1000"
     - name: Archive cards.pdf
       uses: actions/upload-artifact@v3
       with:
         name: cards
-        path: cards.pdf
+        path: "*.pdf"
     - name: Show cards.log
       run: cat cards.log
     - name: Archive compile logs
       uses: actions/upload-artifact@v3
       with:
         name: compile-log
-        path: cards.log
+        path: "*.log"
   gh-pages:
     name: Generate website
     uses: ./.github/workflows/gh-pages.yml

--- a/a4print.tex
+++ b/a4print.tex
@@ -1,0 +1,9 @@
+\documentclass[paper=a4]{scrartcl}
+
+\usepackage{pdfpages}
+
+\begin{document}
+
+\includepdf[pages=-,nup=3x3,noautoscale,frame]{cards}
+
+\end{document}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@ Generate printable playing cards for Pathfinder 2.
 
 [View some sample cards](./cards.pdf)
 
+[Same cards arranged on A4 paper](./a4print.pdf)
+
 These have been generated using the software provided at <https://github.com/potsdam-pnp/pathfinder2-cards>.
 
 {% include LICENSES.md %}


### PR DESCRIPTION
Currently this looks like this:

![image](https://github.com/potsdam-pnp/pathfinder2-cards/assets/961451/f296e2ab-78f6-4b3f-9c24-12a6eb2eaa82)

Some questions:
- Do we want these borders around the cards? Maybe we don't need them once we have colored borders inside the cards
- Should they be moved to some edge, so we need to cut a little bit less?