### PR TITLE
Improve error message for oversized cards

### DIFF
--- a/card-style.cls
+++ b/card-style.cls
@@ -49,11 +49,13 @@
     \ifnum\pgfmathresult=0
       % good
     \else
-      \ClassWarning{card-style}{Previous card needed \pgfmathresult pages too much}
+      \ClassWarning{card-style}{Previous card defined in \LastCardFilePath\space needed \pgfmathresult\space pages too much}
       % make sure remaining cards are not warned against, by pretending there were more cards
       \addtocounter{cards}{\pgfmathresult}
     \fi
   \fi
+  % store current file in LastCardFilePath, in case it's needed later to produce a better error message
+  \xdef\LastCardFilePath{\CurrentFilePath/\CurrentFile}
 
   \stepcounter{cards}
 


### PR DESCRIPTION
- Also report file from which oversized card originated
- In github check, report them as errors and make the check fail