### PR TITLE
Add colored edges to the cards

### DIFF
--- a/card-style.cls
+++ b/card-style.cls
@@ -36,6 +36,27 @@
 
 \newcounter{cards}
 
+\newcommand{\cardStyle@drawCardFrame}[1]{%
+  \def\cardStyle@cardColor{}
+  \ifnum\pdfstrcmp{#1}{Item}=0      \def\cardStyle@cardColor{blue!40} \fi
+  \ifnum\pdfstrcmp{#1}{Action}=0    \def\cardStyle@cardColor{yellow!40} \fi
+  \ifnum\pdfstrcmp{#1}{Spell}=0     \def\cardStyle@cardColor{green!40} \fi
+  \ifnum\pdfstrcmp{#1}{Cantrip}=0   \def\cardStyle@cardColor{green!40} \fi
+  \ifnum\pdfstrcmp{#1}{Focus}=0     \def\cardStyle@cardColor{green!40} \fi
+  
+  \ifnum\pdfstrcmp{\cardStyle@cardColor}{}=0 \else
+    \tikz[remember picture,overlay] {%
+      \draw [color=\cardStyle@cardColor,rounded corners=4mm,line width=4mm]
+        (current page.south west)
+        rectangle
+        (current page.north east);
+    }
+  \fi
+}
+
+\xdef\cardStyle@currentCardCategory{None}
+\AddToHook{shipout/background}{\cardStyle@drawCardFrame{\cardStyle@currentCardCategory}}
+
 \newcommand{\Card}[3]{%
   \clearpage
 
@@ -56,6 +77,8 @@
   \fi
   % store current file in LastCardFilePath, in case it's needed later to produce a better error message
   \xdef\LastCardFilePath{\CurrentFilePath/\CurrentFile}
+
+  \xdef\cardStyle@currentCardCategory{#1}
 
   \stepcounter{cards}
 

--- a/cards.tex
+++ b/cards.tex
@@ -45,7 +45,7 @@
 \input{cards/spells/acid-splash.tex}
 \input{cards/spells/burning-hands.tex}
 \input{cards/spells/chill-touch.tex}
-\input{cards/spells/detect-magic.tex}
+%\input{cards/spells/detect-magic.tex}
 \input{cards/spells/feather-fall.tex}
 \input{cards/spells/force-bolt.tex}
 \input{cards/spells/heal.tex}

--- a/cards.tex
+++ b/cards.tex
@@ -45,7 +45,7 @@
 \input{cards/spells/acid-splash.tex}
 \input{cards/spells/burning-hands.tex}
 \input{cards/spells/chill-touch.tex}
-%\input{cards/spells/detect-magic.tex}
+\input{cards/spells/detect-magic.tex}
 \input{cards/spells/feather-fall.tex}
 \input{cards/spells/force-bolt.tex}
 \input{cards/spells/heal.tex}

--- a/cards/spells/detect-magic.tex
+++ b/cards/spells/detect-magic.tex
@@ -1,7 +1,7 @@
 % Detect Magic
 % https://2e.aonprd.com/Spells.aspx?ID=66
 
-\foreach[evaluate=\level as \lower using int(\level - 1)] \level in {1, ..., 10} {
+\foreach[evaluate=\level as \lowerLevel using int(\level - 1)] \level in {1, ..., 10} {
 \Card{Cantrip}{\level}{Detect Magic}
 
 \CardTraits{Detection, Divination}
@@ -26,8 +26,8 @@
 
 You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies.
 
-\ifnum \lower > 0
-Detect illusion magic for effects with a level \(\le \lower\).
+\ifnum \lowerLevel > 0
+Detect illusion magic for effects with a level \(\le \lowerLevel\).
 \else
 You cannot detect illusion magic.
 \fi


### PR DESCRIPTION
Based on the type, add colored edges. The colors are picked somewhat randomly for now:
- yellow for actions
- blue for items
- green for spells

Test print:

![20230828_012622](https://github.com/potsdam-pnp/pathfinder2-cards/assets/961451/998dece8-3383-4f1e-bf3c-5cc2df64da2d)
