### PR TITLE
Make list of cards in final pdf customizable

### DIFF
--- a/card-filter.tex
+++ b/card-filter.tex
@@ -1,0 +1,35 @@
+\newif\ifvisible
+
+\pgfkeys{
+  /card filter/.is family, /card filter,
+  visible/.is if=visible,
+  %
+  default/.style={visible},
+  type/.estore in=\type,
+  level/.estore in=\tlevel,
+  title/.estore in=\title,
+  source book/.estore in=\sourceBook
+  %compute/.style=default
+}
+
+\pgfkeys{
+  /card filter definition/.is family, /card filter definition,
+  .compute/.style = {/card filter/compute/.code = {#1}},
+  .append compute/.estyle = {/card filter/compute/.append code = {#1}},
+  .style compute/.estyle = {/card filter/compute/.style = {#1}},
+  %
+  visible/.style = {.style compute={/card filter/visible=true}},
+  invisible/.style = {.style compute={/card filter/visible=false}},
+  %
+  visible/level/.style = {.append compute={
+    \ifnum\pdfstrcmp{#1}{\tlevel}=0
+      \pgfkeysalso{visible=true}
+    \fi
+  }}
+}
+
+\newcommand{\filter}[1]{%
+  \pgfkeys{/card filter definition,#1}
+}
+
+\NewDocumentEnvironment{invisible}{+b}{}{}

--- a/card-filter.tex
+++ b/card-filter.tex
@@ -12,24 +12,40 @@
   %compute/.style=default
 }
 
+\def\makeVisibleCommand#1#2{
+  \pgfkeys{
+    /card filter definition,
+    visible/#1/.style = {/card filter definition/.append compute={
+      \ifnum\pdfstrcmp{##1}{#2}=0
+        \pgfkeysalso{visible=true}
+      \fi
+    }},
+    invisible/#1/.style = {/card filter definition/.append compute={
+      \ifnum\pdfstrcmp{##1}{#2}=0
+        \pgfkeysalso{visible=false}
+      \fi
+    }}
+  }
+}
+
 \pgfkeys{
   /card filter definition/.is family, /card filter definition,
   .compute/.style = {/card filter/compute/.code = {#1}},
   .append compute/.estyle = {/card filter/compute/.append code = {#1}},
   .style compute/.estyle = {/card filter/compute/.style = {#1}},
   %
-  visible/.style = {.style compute={/card filter/visible=true}},
-  invisible/.style = {.style compute={/card filter/visible=false}},
-  %
-  visible/level/.style = {.append compute={
-    \ifnum\pdfstrcmp{#1}{\tlevel}=0
-      \pgfkeysalso{visible=true}
-    \fi
-  }}
+  visible/all/.style = {/card filter definition/.style compute={/card filter/visible=true}},
+  invisible/all/.style = {/card filter definition/.style compute={/card filter/visible=false}},
 }
+\makeVisibleCommand{level}{\tlevel}
+\makeVisibleCommand{title}{\title}
+\makeVisibleCommand{type}{\type}
+\makeVisibleCommand{source book}{\sourceBook}
 
 \newcommand{\filter}[1]{%
   \pgfkeys{/card filter definition,#1}
 }
 
-\NewDocumentEnvironment{invisible}{+b}{}{}
+\newcommand{\showCards}[1]{%
+  \pgfkeys{/card filter definition,invisible/all,visible/.cd,#1}
+}

--- a/card-style.cls
+++ b/card-style.cls
@@ -23,6 +23,8 @@
 
 \input{symbols.tex}
 
+\input{card-filter.tex}
+
 \setlength\parindent{0pt} % todo: avoid in favor of some komascript feature
 \setlength\parskip{4pt} % todo: avoid in favor of some komascript feature
 
@@ -123,10 +125,14 @@
 
   \stepcounter{cards}
 
+  \pgfkeys{/card filter, type=#1, level=#2, title=#3, source book=#4, compute}
+
+  \ifvisible \else \begin{invisible} \fi
+
   \bookmark[page=\thepage, level=1]{#3 \ifnum\pdfstrcmp{#2}{}=0\else (#1 #2)\fi}%
   \raisebox{0pt}[0pt][0pt]{}%
   \hfill\raisebox{1.2em}[0pt][0pt]{\normalfont\postamt#1 #2}%
   \section{#3 \hfill \IfValueT{#4}{\IfValueT{#5}{\Reference{#4}{#5}}}}%
-}{}
+}{ \ifvisible \else \end{invisible} \fi }
 
 \pagestyle{empty}

--- a/card-style.cls
+++ b/card-style.cls
@@ -96,14 +96,7 @@
 \xdef\cardStyle@currentCardCategory{None}
 \AddToHook{shipout/background}{\cardStyle@drawCardFrame{\cardStyle@currentCardCategory}}
 
-% \long\def\cardStyle@swallowContent#1\end#2{%
-%   \ifnum\pdfstrcmp{#2}{card}=0
-%     \end{card}
-%   \else
-%     \expandafter\cardStyle@swallowContent
-%   \fi
-% }
-
+% Code to swallow cards that should not be visible
 \def\cardStyle@swallowCode#1{
   \ifnum\pdfstrcmp{#1}{card}=0%
     \end{card}%

--- a/card-style.cls
+++ b/card-style.cls
@@ -96,13 +96,42 @@
 \xdef\cardStyle@currentCardCategory{None}
 \AddToHook{shipout/background}{\cardStyle@drawCardFrame{\cardStyle@currentCardCategory}}
 
+% \long\def\cardStyle@swallowContent#1\end#2{%
+%   \ifnum\pdfstrcmp{#2}{card}=0
+%     \end{card}
+%   \else
+%     \expandafter\cardStyle@swallowContent
+%   \fi
+% }
+
+\def\cardStyle@swallowCode#1{
+  \ifnum\pdfstrcmp{#1}{card}=0%
+    \end{card}%
+  \else
+    \expandafter\cardStyle@swallowContent
+  \fi
+}
+
+\long\def\cardStyle@swallowContent#1{%
+  \def\a{#1}%
+  \def\b{\end}%
+  \ifx\a\b
+    \expandafter\cardStyle@swallowCode
+  \else
+    \expandafter\cardStyle@swallowContent
+  \fi
+}
+
 % \begin{card}{<card-type>}{<level>}{<title>}[<source-book>][<source-page>]
 % ...
 % \end{card}
 % TODO: make reference mandatory, but we need to define all the references first
 \NewDocumentEnvironment{card}{mmmoo}{%
-  \clearpage
-
+  \pgfkeys{/card filter, type=#1, level=#2, title=#3, source book=#4, compute}%
+  \ifvisible
+%
+  \clearpage%
+%
   % Check that last card fitted on one page
   \pgfmathparse{int(\value{cards})}
   \ifnum\pgfmathresult=0
@@ -125,14 +154,13 @@
 
   \stepcounter{cards}
 
-  \pgfkeys{/card filter, type=#1, level=#2, title=#3, source book=#4, compute}
-
-  \ifvisible \else \begin{invisible} \fi
-
   \bookmark[page=\thepage, level=1]{#3 \ifnum\pdfstrcmp{#2}{}=0\else (#1 #2)\fi}%
   \raisebox{0pt}[0pt][0pt]{}%
   \hfill\raisebox{1.2em}[0pt][0pt]{\normalfont\postamt#1 #2}%
   \section{#3 \hfill \IfValueT{#4}{\IfValueT{#5}{\Reference{#4}{#5}}}}%
-}{ \ifvisible \else \end{invisible} \fi }
+  \else
+    \expandafter\cardStyle@swallowContent
+  \fi
+}{}
 
 \pagestyle{empty}

--- a/cards.tex
+++ b/cards.tex
@@ -2,11 +2,9 @@
 
 \begin{document}
 
-\filter{%
-  invisible,
-  visible/level=1,
-  visible/level=0
-}
+\showCards{all}
+%\showCards{title=Breastplate}
+%\showCards{level=1,level=0}
 
 \input{cards/cards.tex}
 

--- a/cards.tex
+++ b/cards.tex
@@ -2,6 +2,12 @@
 
 \begin{document}
 
+\filter{%
+  invisible,
+  visible/level=1,
+  visible/level=0
+}
+
 \input{cards/cards.tex}
 
 \end{document}


### PR DESCRIPTION
By adding some `\filter` command, that uses somewhat weird pgfkeys logic. 
We swallow the content of cards, that should not be visible, by looking for some `\end{cards}` (so this will break whenever we'll do recursive cards, but we should not do that). We only read ahead token by token (or group by group).

This allows to display only some cards by doing things like

```
\showCards{all} % show all cards
\showCards{title=Heal} % show all cards with Heal title
\showCards{title=Heal, level=1} % show all cards named "Heal" or that have level=1
\showCards{type=Spell} % show only spells
```

You can't really express everything, as the conditions are "OR"-ed together.