### PR TITLE
Make boxes smaller

### DIFF
--- a/cards/items/dagger.tex
+++ b/cards/items/dagger.tex
@@ -9,7 +9,7 @@
 
 \Action[Attack]{CRB}{471}{1}{Strike}
 
-\CheckRoll{MeleeAttack}{str/dex, prof}
+\CheckRoll{MeleeAttack}[r]{str/dex, prof}
 \DamageRoll{Piercing}[Slashing]{1d4}{str}
 
 \Action[Attack]{CRB}{283}{1}{Throw}

--- a/cards/items/scimitar.tex
+++ b/cards/items/scimitar.tex
@@ -19,7 +19,7 @@
 
 If you already attacked a different target this turn using this weapon.
 
-\CheckRoll{MeeleAttack}{str, prof, 1}
+\CheckRoll{MeeleAttack}[r]{str, prof, 1}
 \DamageRoll{Slashing}{1d6}{str}
 
 \vfill
@@ -45,14 +45,14 @@ If you already attacked a different target this turn using this weapon.
 
 \Action[Attack]{CRB}{471}{1}{Strike}
 
-\CheckRoll{MeeleAttack}{str, prof, 1}
+\CheckRoll{MeeleAttack}[r]{str, prof, 1}
 \DamageRoll{Slashing}{1d6}{str}
 
 \Action[Attack]{CRB}{471}{1}{Sweeping Strike}
 
 If you already attacked a different target this turn using this weapon.
 
-\CheckRoll{MeeleAttack}{str, prof, 1, 1}
+\CheckRoll{MeeleAttack}[r]{str, prof, 1, 1}
 \DamageRoll{Slashing}{1d6}{str}
 
 \vfill

--- a/cards/items/smoking-sword.tex
+++ b/cards/items/smoking-sword.tex
@@ -9,7 +9,7 @@
 
 \Action[Attack]{CRB}{471}{1}{Strike}
 
-\CheckRoll{MeeleAttack}{str, prof, 1}
+\CheckRoll{MeeleAttack}[r]{str, prof, 1}
 \DamageRoll{Slashing}[Piercing]{1d8}{str}
 \DamageRoll{Fire}{1}{}
 

--- a/cards/items/torch.tex
+++ b/cards/items/torch.tex
@@ -8,7 +8,7 @@ A torch sheds bright light in a 20-foot radius (and dim light to the next 20 fee
 It can be used as an improvised weapon.
 
 \Action[Attack]{CRB}{471}{1}{Strike}
-\CheckRoll{MeleeAttack}{str, prof ~-~ 2} %TODO '-' should be supported by \CheckFormula
+\CheckRoll{MeleeAttack}[r]{str, prof ~-~ 2} %TODO '-' should be supported by \CheckFormula
 \DamageRoll{Bludgeoning}{1d4}{}
 \DamageRoll{Fire}{1}{}
 

--- a/cards/spells/acid-splash.tex
+++ b/cards/spells/acid-splash.tex
@@ -16,12 +16,13 @@
 Target one creature within 30 feet.
 
 \CheckRoll{SpellAttack}{spell atk}
-
 % TODO: add icon for "splash" damage?
 \ifnum \level < 3
-\DamageRoll{Acid}{1d6}{}\DamageRoll{Acid}{1 (splash)}{}
+\DamageRoll{Acid}{1d6}{}
+\DamageRoll{Acid}{1 (splash)}{}
 \else
-\DamageRoll{Acid}{\dice{}d6}{key}\DamageRoll{Acid}{\dice{} (splash)}{}
+\DamageRoll{Acid}{\dice{}d6}{key}
+\DamageRoll{Acid}{\dice{} (splash)}{}
 \fi
 
 \pfsymbol{critical-success} The target takes \pfsymbol{acid} \half{} persistent damage.

--- a/cards/spells/shocking-grasp.tex
+++ b/cards/spells/shocking-grasp.tex
@@ -12,7 +12,7 @@ Target 1 creature you can touch.
 
 If target is wearing metal armor or made of metal.
 
-\CheckRoll{Spell Attack}{spell atk, 1}
+\CheckRoll{Spell Attack}[r]{spell atk, 1}
 % TODO: how to express persistent damage?
 \DamageRoll{Electricity}{2d12}{} \DamageRoll{Electricity}{1d4}{} (persistent)
 

--- a/symbols.tex
+++ b/symbols.tex
@@ -1,4 +1,4 @@
-\tikzset{roll box/.style={inner ysep=0.7em, fill=black!20}}
+\tikzset{roll box/.style={inner ysep=0.5em, inner xsep=0.1em, fill=black!20}}
 \tikzset{check roll box/.style={roll box, fill=blue!20}}
 \tikzset{damage roll box/.style={roll box, fill=red!20, rounded corners=0.5em}}
 \tikzset{healing roll box/.style={roll box, fill=green!20, rounded corners=0.5em}}
@@ -88,30 +88,39 @@
   \fi           
 }
 
-\newcommand{\FormulaVariable}[2]{
+% \FormulaVariable[<mod alignment>]{<mod desc>}{<content>}
+\newcommand{\FormulaVariable}[3][c]{
   \operatorname{
-    \tikz[baseline] \path
-      node[draw, shape=rectangle, anchor=base, fill=white] (box) { #2 }
-      (box.south) node[below=-0.5ex] {\makebox[0pt][c]{\scriptsize \engschrift #1}};
+    \tikz[baseline, trim right=(box.east)] \path
+      node[draw, shape=rectangle, anchor=base, fill=white] (box) { #3 }
+      \ifnum\pdfstrcmp{#1}{c}=0
+      (box.south) node[below=-0.5ex] {\makebox[0pt][#1]{\scriptsize \engschrift #2}}
+      \fi
+      \ifnum\pdfstrcmp{#1}{r}=0
+      (box.south east) +(0.5em, 0em) node[below=-0.5ex] {\makebox[0pt][#1]{\scriptsize \engschrift #2}}
+      \fi
+      ;
     }
   }
 
-\NewDocumentCommand{\CheckFormula}{mo}{
+% \CheckFormula[<mod alignment>]{<mod desc>}[<DC>]
+\NewDocumentCommand{\CheckFormula}{O{c}mo}{
   \(
-    \operatorname{1d20} + \FormulaVariable{
-      \foreach[count=\index] \summand in {#1}
+    \operatorname{1d20} + \FormulaVariable[#1]{
+      \foreach[count=\index] \summand in {#2}
         {\ifnum \index > 1 ~+~ \fi \summand}
-      }{\phantom{100}}\IfValueT{#2}{\ge \operatorname{\mbox{#2}}}%
+      }{\phantom{100}}\IfValueT{#3}{\ge \operatorname{\mbox{#3}}}%
   \)%
 }
 
-% \CheckRoll{<check type>}{<mod desc>}[<DC>]
-\NewDocumentCommand{\CheckRoll}{mmo}{
+% \CheckRoll{<check type>}[<mod alignment>]{<mod desc>}[<DC>]
+\NewDocumentCommand{\CheckRoll}{mO{c}mo}{
   \tikz[baseline=(content.base)]{
-    \node (content)  {
-      \strut\smash{
-        \parbox[t]{1.25em}{\CheckType{#1}[]}
-        \CheckFormula{#2}[#3]%
+    \node (content)  {%
+      \footnotesize
+      \strut\smash{%
+        % \parbox[t]{1.25em}{\CheckType{#1}[]}
+        \CheckFormula[#2]{#3}[#4]%
       }%
     };
     \begin{pgfonlayer}{background}
@@ -123,7 +132,8 @@
 % \DamageRoll{<damage type>}[<alternative damage type>]{<damage roll>}{<mod descr>}
 \NewDocumentCommand{\DamageRoll}{momm}{
   \tikz[baseline=(content.base)]{
-    \node (content) {
+    \node (content) {%
+      \footnotesize
       \strut\smash{
         \IfValueTF{#2}
           {%
@@ -140,18 +150,19 @@
             \FormulaVariable{\part}{\phantom{100}}
           }
         \)
-      }
+      }%
     };
     \begin{pgfonlayer}{background}
       \node [fit=(content), damage roll box] (box) {};
-    \end{pgfonlayer}
-  }
+    \end{pgfonlayer}%
+  }%
 }
 
 % \HealingRoll{<healing roll>}{<mod descr>}
 \NewDocumentCommand{\HealingRoll}{mm}{
   \tikz[baseline=(content.base)]{
-    \node (content) {
+    \node (content) {%
+    \footnotesize
       \strut\smash{
         \(
           \mbox{#1}


### PR DESCRIPTION
Make boxes smaller so they are more likely to fit into one line:

1. reduce font size
2. reduce inner sep
3. sprinkle % to get rid of whitespace
4. remove placeholder for roll icon

The text under the FormulaVariables started to leak over the boxes, so I added an option to have it right-aligned instead of centered under the box.

With these changes, the Strike of the smoking sword fits comfortably on one line:

![image](https://github.com/potsdam-pnp/pf2e-cards/assets/961451/6d7a9058-88e3-4ed4-a9b2-a8a7933f5c62)

Same for the Cast of the higher-level acid splash:

![image](https://github.com/potsdam-pnp/pf2e-cards/assets/961451/63b2e3e4-1e24-46c1-9120-568111545348)

An extreme example for the right-aligned small text is the Sweeping Strike of the +1 Scimitar:

![image](https://github.com/potsdam-pnp/pf2e-cards/assets/961451/3693cc2d-d452-46d0-9417-0fa55e9a5e33)
