### PR TITLE
color-palette: Nord

### DIFF
--- a/card-style.cls
+++ b/card-style.cls
@@ -43,6 +43,8 @@
 
 \newcounter{cards}
 
+\input{palette.tex}
+
 \newif\ifCardStyle@shouldDrawBorder
 \pgfkeys{
   /cardStyle border/.is family, /cardStyle border,
@@ -59,13 +61,13 @@
   type/.add code={\ifnum \pdfstrcmp{#1}{}=0\else}{\fi}, % don't do anything for an empty type
 %
   type/.cd,
-  Item/.style      = {color=blue!40},
-  Action/.style    = {color=yellow!40},
-  Spell/.style     = {color=green!40},
-  Cantrip/.style   = {color=green!40},
-  Focus/.style     = {color=green!40},
-  Rule/.style      = {color=gray!40},
-  Condition/.style = {color=gray!40},
+  Item/.style      = {color=accent-blue},
+  Action/.style    = {color=accent-red},
+  Spell/.style     = {color=accent-purple},
+  Cantrip/.style   = {color=accent-purple!40},
+  Focus/.style     = {color=accent-purple!70},
+  Rule/.style      = {color=accent-gray},
+  Condition/.style = {color=accent-brown},
   .unknown/.style  = {shouldDrawBorder=false}
 }
 

--- a/palette.tex
+++ b/palette.tex
@@ -1,0 +1,12 @@
+% Based on https://lospec.com/palette-list/nord-theme
+
+\definecolor{accent-blue}{HTML}{81a1c1}
+\definecolor{accent-brown}{HTML}{ebcb8b}
+\definecolor{accent-gray}{HTML}{4c566a}
+\definecolor{accent-green}{HTML}{a3be8c}
+\definecolor{accent-purple}{HTML}{b48ead}
+\definecolor{accent-red}{HTML}{bf616a}
+
+\definecolor{box-red}{HTML}{d08770 }
+\definecolor{box-blue}{HTML}{88c0d0 }
+\definecolor{box-green}{HTML}{a3be8c}

--- a/symbols.tex
+++ b/symbols.tex
@@ -1,8 +1,10 @@
+\input{palette.tex}
+
 \tikzset{roll box/.style={inner ysep=0.5em, inner xsep=0.1em, fill=black!20}}
-\tikzset{check roll box/.style={roll box, fill=blue!20}}
-\tikzset{damage roll box/.style={roll box, fill=red!20, rounded corners=0.5em}}
-\tikzset{healing roll box/.style={roll box, fill=green!20, rounded corners=0.5em}}
-\tikzset{effect box/.style={roll box, fill=red!20, rounded corners=0.5em}}
+\tikzset{check roll box/.style={roll box, fill=box-blue}}
+\tikzset{damage roll box/.style={roll box, fill=box-red, rounded corners=0.5em}}
+\tikzset{healing roll box/.style={roll box, fill=box-green, rounded corners=0.5em}}
+\tikzset{effect box/.style={roll box, fill=box-red, rounded corners=0.5em}}
 
 \newcommand{\pfsymbol}[1]{%
   \mbox{\pfsymbols\selectfont#1}


### PR DESCRIPTION
Based on https://www.nordtheme.com/ and https://lospec.com/palette-list/nord-theme.

![image](https://github.com/potsdam-pnp/pf2e-cards/assets/1448874/921edf20-9a8a-4dff-bbda-3a7bc8096125)

Contributes to #42.
