### PR TITLE
White font color for card type and level in top-right corner

### DIFF
--- a/card-style.cls
+++ b/card-style.cls
@@ -152,7 +152,7 @@
 
   \bookmark[page=\thepage, level=1]{#3 \ifnum\pdfstrcmp{#2}{}=0\else (#1 #2)\fi}%
   \raisebox{0pt}[0pt][0pt]{}%
-  \hfill\raisebox{1.2em}[0pt][0pt]{\normalfont\postamt#1 #2}%
+  \hfill\raisebox{1.2em}[0pt][0pt]{\normalfont\color{white}\postamt#1 #2}%
   \section{#3 \hfill \IfValueT{#4}{\IfValueT{#5}{\Reference{#4}{#5}}}}%
   \else
     \expandafter\cardStyle@swallowContent


### PR DESCRIPTION
For now this might work, just setting the color to white.

Going forward, the font color should depend on the background color. That topic itself is quite complicated, so maybe we just explicitly specify color pairs for `bg` and `fg` here, where `bg` is the card border color and `fg` the text foreground color.

Just wanted to get this started, though…