### PR TITLE
Extract metadata information

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -30,7 +30,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: cards
-        path: "*.pdf"
+        path: |
+          *.pdf
+          metadata.txt
     - name: Show cards.log
       run: cat cards.log
     - name: Archive compile logs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.synctex.gz
 *.xdv
 filter-config.tex
+metadata.txt

--- a/card-filter.tex
+++ b/card-filter.tex
@@ -122,15 +122,17 @@
   source book/.estore in=\cardSourceBook
 }
 
+\def\allowedControlSequencesForFilteringCards{
+  \def\and{and}%
+  \def\or{or}%
+  \def\title{title}%
+  \def\level{level}%
+  \def\type{type}%
+  \def\ne{<>}%
+}
+
 \NewDocumentEnvironment{filterBy}{}{%
-  \def\allowedControlSequences{%
-    \def\and{and}%
-    \def\or{or}%
-    \def\title{title}%
-    \def\level{level}%
-    \def\type{type}%
-    \def\ne{<>}%
-  }%
+  \let\allowedControlSequences=\allowedControlSequencesForFilteringCards
   \startExpression
 }{%
   \ifnum \pdfstrcmp{\currentType}{bool}=0 \else
@@ -143,6 +145,49 @@
   \pgfqkeys{/card attributes}{#1}%
   \cardFilter
   \ifnum\intResult=1
+  \clearpage
+  \writeMetadata
+}
+
+% Write metadata information about some file
+
+\newwrite\metadataFile
+\openout\metadataFile=metadata.txt
+
+\pgfkeys{
+  /collections/all/.style={},
+  /collections/by name/.code={%
+    \pgfkeysalso{/collections/#1}%
+    \ifnum\intResult=1
+      \immediate\write\metadataFile{ collection=#1}
+    \fi
+  }
+}
+
+\NewDocumentEnvironment{collection}{m}{%
+  \let\allowedControlSequences=\allowedControlSequencesForFilteringCards
+  \startExpression
+}{%
+  \ifnum \pdfstrcmp{\currentType}{bool}=0 \else
+    \errmessage{Wrong type of collection expression, expected bool but got \currentType}
+  \fi
+  \global\let\collectionCurrentCalc=\currentCalc
+  \gdef\evalAfterGroup{
+    \pgfkeys{
+      /collections/#1/.code/.expand once=\collectionCurrentCalc,
+      /collections/all/.append style={/collections/by name=#1}
+    }
+  }
+  \aftergroup\evalAfterGroup
+}
+
+\def\writeMetadata{
+  \immediate\write\metadataFile{page=\thepage}%
+  \immediate\write\metadataFile{ title=\cardTitle}%
+  \immediate\write\metadataFile{ level=\cardLevel}%
+  \immediate\write\metadataFile{ type=\cardType}%
+  \immediate\write\metadataFile{ card source book=\cardSourceBook}%
+  \pgfkeys{/collections/all}%
 }
 
 % Implementation of semantics and type-checking

--- a/card-filter.tex
+++ b/card-filter.tex
@@ -151,8 +151,8 @@
 
 % Write metadata information about some file
 
-\newwrite\metadataFile
-\openout\metadataFile=metadata.txt
+\immediate\newwrite\metadataFile
+\immediate\openout\metadataFile=metadata.txt
 
 \pgfkeys{
   /collections/all/.style={},
@@ -186,7 +186,7 @@
   \immediate\write\metadataFile{ title=\cardTitle}%
   \immediate\write\metadataFile{ level=\cardLevel}%
   \immediate\write\metadataFile{ type=\cardType}%
-  \immediate\write\metadataFile{ card source book=\cardSourceBook}%
+  \immediate\write\metadataFile{ source book=\cardSourceBook}%
   \pgfkeys{/collections/all}%
 }
 

--- a/card-style.cls
+++ b/card-style.cls
@@ -123,7 +123,7 @@
 % \end{card}
 % TODO: make reference mandatory, but we need to define all the references first
 \NewDocumentEnvironment{card}{mmmoo}{%
-  \ifVisible[type=#1, level=#2, title=#3, source book=#4]
+  \ifVisible[type=#1, level=#2, title=#3, source book=#4]%
 %
   \clearpage%
 %


### PR DESCRIPTION
Write some metadata.txt file, that contains metadata about the cards.
This file can be used to define which files to display, for example in /show commands or for the website.

We also allow to define collections of cards in the language used also to filter cards. Then, these collections are also written to the metadata.txt file.
