### PR TITLE
Add substitutor suggestion to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,11 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
+  nixConfig = {
+    extra-substituters = "https://potsdam-pnp.cachix.org";
+    extra-trusted-public-keys = "potsdam-pnp.cachix.org-1:ZbQQiYz7KI9iZLOwECW6ErfJLFowbVOrNUF7PXJGLhw=";
+  };
+
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: 
       let pkgs = nixpkgs.legacyPackages.${system}; in rec {


### PR DESCRIPTION
I'm not sure if we should add this. When using this flake, you will get a suggestion to add the resp binary cache.